### PR TITLE
Update functional tests

### DIFF
--- a/src/test-requirements.txt
+++ b/src/test-requirements.txt
@@ -1,2 +1,3 @@
 # zaza
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/src/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/src/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,0 +1,5 @@
+applications:
+  cinder-purestorage:
+    options:
+      san-ip: {{ OS_PURESTORAGE_SAN_IP }}
+      pure-api-token: {{ OS_PURESTORAGE_API_TOKEN }}

--- a/src/tests/bundles/xenial-ocata.yaml
+++ b/src/tests/bundles/xenial-ocata.yaml
@@ -40,12 +40,10 @@ applications:
     - '2'
   cinder-purestorage:
     series: xenial
-    charm: cinder-purestorage
+    charm: ../../../cinder-purestorage
     options:
 # Add config options here
       driver-source: ppa:narindergupta/purestorage
-      san-ip: 10.243.19.250
-      pure-api-token: ac0a534f-b682-777a-45a4-15a02e0d5c7e
       protocol: iscsi
       volume-backend-name: cinder-pure
   rabbitmq-server:

--- a/src/tests/tests.yaml
+++ b/src/tests/tests.yaml
@@ -2,7 +2,7 @@ charm_name: cinder-purestorage
 tests:
   - tests.tests_cinder_purestorage.CinderpurestorageTest
 configure:
-  - zaza.charm_tests.keystone.setup.add_demo_user
+  - zaza.openstack.charm_tests.keystone.setup.add_demo_user
 gate_bundles:
   - xenial-ocata
 smoke_bundles:

--- a/src/tests/tests_cinder_purestorage.py
+++ b/src/tests/tests_cinder_purestorage.py
@@ -20,8 +20,8 @@ import logging
 import uuid
 
 import zaza.model
-import zaza.charm_tests.test_utils as test_utils
-import zaza.utilities.openstack as openstack_utils
+import zaza.openstack.charm_tests.test_utils as test_utils
+import zaza.openstack.utilities.openstack as openstack_utils
 
 
 class CinderpurestorageTest(test_utils.OpenStackBaseTest):
@@ -35,29 +35,6 @@ class CinderpurestorageTest(test_utils.OpenStackBaseTest):
         cls.model_name = zaza.model.get_juju_model()
         cls.cinder_client = openstack_utils.get_cinder_session_client(
             cls.keystone_session)
-
-    def test_cinder_config(self):
-        logging.info('purestorage')
-        expected_contents = {
-            'cinder-purestorage': {
-                'san_ip': ['10.243.19.250'],
-                'pure_api_token': ['ac0a534f-b682-777a-45a4-15a02e0d5c7e'],
-                'volume_driver':
-                    ['cinder.volume.drivers.pure.PureISCSIDriver'],
-                'volume_backend_name': ['cinder-pure']
-            }
-        }
-
-        zaza.model.run_on_leader(
-            'cinder',
-            'sudo cp /etc/cinder/cinder.conf /tmp/',
-            model_name=self.model_name)
-        zaza.model.block_until_oslo_config_entries_match(
-            'cinder',
-            '/tmp/cinder.conf',
-            expected_contents,
-            model_name=self.model_name,
-            timeout=2)
 
     def test_create_volume(self):
         test_vol_name = "zaza{}".format(uuid.uuid1().fields[0])


### PR DESCRIPTION
* Expose environment variables OS_PURESTORAGE_SAN_IP and
  OS_PURESTORAGE_API_TOKEN.
* Update functional test after zaza reorg
* Remove test_cinder_config as its environment specific and
  superseded by the volume creation test.